### PR TITLE
Fixes IE issue when setUp function not defined in tests

### DIFF
--- a/src/bunit.js
+++ b/src/bunit.js
@@ -7,8 +7,8 @@ define(['lib/reload'], function(reload) {
     var HTMLOutput = function(target) {
         return function(report) {
             target.innerHTML += '<div class="' + report.state + '">' + report.text + '</div>';
-        }
-    }
+        };
+    };
 
     // core logic
     var bunit = function(setName, newTests) {
@@ -62,7 +62,7 @@ define(['lib/reload'], function(reload) {
                     var model = bunit._tests[i];
                     var testSet = model.tests;
 
-                    var setUp = 'setUp' in testSet? testSet.setUp: function() {};
+                    var setUp = 'setUp' in testSet? testSet.setUp: function() { return []; };
                     delete testSet.setUp;
 
                     var tearDown = 'tearDown' in testSet? testSet.tearDown: function() {};


### PR DESCRIPTION
I've been trying out bunit, and it's been great so far. However, I found an issue with IE 8 that this pull request addresses. The issue is as follows:
1. Set up bunit with a single test case
2. Do not define a setUp function in the test case
3. Run the tests in IE 8

Expected: test case runs, reporting success/fail
Actual: IE reports "TypeError: Object expected"

This works fine in firefox and chrome. The issue appears to be IE not handling a missing return value.
